### PR TITLE
Style loading screen

### DIFF
--- a/about.html
+++ b/about.html
@@ -54,7 +54,11 @@
     <link rel="stylesheet" href="/css/article.css">
 </head>
 <body>
-    <div id='app' data-local='tw' data-page-name='about.html'>
+    <!-- loading overlay -->
+    <div id="loading-overlay" style="background-color: white; position:absolute; top:0px; left:0px; width:100%; height:100%; z-index:1000;"></div>
+
+    <!-- app -->
+    <div id='app' v-cloak data-local='tw' data-page-name='about.html'>
         <!-- Navbar -->
         <app-nav-bar></app-nav-bar>
 

--- a/css/style.css
+++ b/css/style.css
@@ -1,4 +1,5 @@
 /* FILE STRUCTURE
+  - loading style
   - general settings
   - social media
   - donate/support
@@ -11,6 +12,22 @@
   - checkbox switch
   - back to top
 */
+
+/* ===============
+    LOADING STYLE
+  ================ */
+
+[v-cloak] > * { display:none; }
+[v-cloak]::before { 
+  content: "Loading...";
+  display: block;
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  font-size: 2em;
+}
+#loading-overlay {display: none;}
 
 /* ==================
     GENERAL SETTINGS
@@ -317,6 +334,7 @@ img.radical {
 /* ================
     KEYCAP STYLING
   ================= */
+
 .keycap {
   white-space: nowrap;
   border: 1.5px solid #aaa;

--- a/dictionary.html
+++ b/dictionary.html
@@ -54,7 +54,11 @@
     <link rel="stylesheet" href="/css/dictionary.css">
 </head>
 <body>
-    <div id='app' data-local='tw' data-page-name='dictionary.html'>
+    <!-- loading overlay -->
+    <div id="loading-overlay" style="background-color: white; position:absolute; top:0px; left:0px; width:100%; height:100%; z-index:1000;"></div>
+
+    <!-- app -->
+    <div id='app' v-cloak data-local='tw' data-page-name='dictionary.html'>
     <!-- Navbar -->
     <app-nav-bar></app-nav-bar>
 

--- a/download.html
+++ b/download.html
@@ -54,7 +54,11 @@
     <link rel="stylesheet" href="/css/page-with-sticky-toc.css">
 </head>
 <body>
-    <div id='app' data-local='tw' data-page-name='download.html'>
+    <!-- loading overlay -->
+    <div id="loading-overlay" style="background-color: white; position:absolute; top:0px; left:0px; width:100%; height:100%; z-index:1000;"></div>
+
+    <!-- app -->
+    <div id='app' v-cloak data-local='tw' data-page-name='download.html'>
         <!-- Navbar -->
         <app-nav-bar></app-nav-bar>
     

--- a/en/about.html
+++ b/en/about.html
@@ -54,7 +54,11 @@
     <link rel="stylesheet" href="/css/article.css">
 </head>
 <body>
-    <div id='app' data-local='en' data-page-name='about.html'>
+    <!-- loading overlay -->
+    <div id="loading-overlay" style="background-color: white; position:absolute; top:0px; left:0px; width:100%; height:100%; z-index:1000;"></div>
+
+    <!-- app -->
+    <div id='app' v-cloak data-local='en' data-page-name='about.html'>
         <!-- Navbar -->
         <app-nav-bar></app-nav-bar>
 

--- a/en/dictionary.html
+++ b/en/dictionary.html
@@ -54,7 +54,11 @@
     <link rel="stylesheet" href="/css/dictionary.css">
 </head>
 <body>
-    <div id='app' data-local='en' data-page-name='dictionary.html'>
+    <!-- loading overlay -->
+    <div id="loading-overlay" style="background-color: white; position:absolute; top:0px; left:0px; width:100%; height:100%; z-index:1000;"></div>
+
+    <!-- app -->
+    <div id='app' v-cloak data-local='en' data-page-name='dictionary.html'>
     <!-- Navbar -->
     <app-nav-bar></app-nav-bar>
 

--- a/en/download.html
+++ b/en/download.html
@@ -54,7 +54,11 @@
     <link rel="stylesheet" href="/css/page-with-sticky-toc.css">
 </head>
 <body>
-    <div id='app' data-local='en' data-page-name='download.html'>
+    <!-- loading overlay -->
+    <div id="loading-overlay" style="background-color: white; position:absolute; top:0px; left:0px; width:100%; height:100%; z-index:1000;"></div>
+
+    <!-- app -->
+    <div id='app' v-cloak data-local='en' data-page-name='download.html'>
         <!-- Navbar -->
         <app-nav-bar></app-nav-bar>
     

--- a/en/faq.html
+++ b/en/faq.html
@@ -53,7 +53,11 @@
     <link rel="stylesheet" href="/css/style.css">
 </head>
 <body>
-    <div id='app' data-local='en' data-page-name='faq.html'>
+    <!-- loading overlay -->
+    <div id="loading-overlay" style="background-color: white; position:absolute; top:0px; left:0px; width:100%; height:100%; z-index:1000;"></div>
+
+    <!-- app -->
+    <div id='app' v-cloak data-local='en' data-page-name='faq.html'>
         <!-- Navbar -->
         <app-nav-bar></app-nav-bar>
 

--- a/en/index.html
+++ b/en/index.html
@@ -55,7 +55,11 @@
     <link rel="stylesheet" href="/css/index.css">
 </head>
 <body>
-    <div id='app' data-local='en' data-page-name='index.html'>
+    <!-- loading overlay -->
+    <div id="loading-overlay" style="background-color: white; position:absolute; top:0px; left:0px; width:100%; height:100%; z-index:1000;"></div>
+
+    <!-- app -->
+    <div id='app' v-cloak data-local='en' data-page-name='index.html'>
     <!-- Navbar -->
     <app-nav-bar></app-nav-bar>
 

--- a/en/radicals-and-examples.html
+++ b/en/radicals-and-examples.html
@@ -54,7 +54,11 @@
     <link rel="stylesheet" href="/css/radicals-and-examples.css">
 </head>
 <body>
-    <div id='app' data-local='en' data-page-name='radicals-and-examples.html'>
+    <!-- loading overlay -->
+    <div id="loading-overlay" style="background-color: white; position:absolute; top:0px; left:0px; width:100%; height:100%; z-index:1000;"></div>
+
+    <!-- app -->
+    <div id='app' v-cloak data-local='en' data-page-name='radicals-and-examples.html'>
         <!-- Navbar -->
         <app-nav-bar></app-nav-bar>
 

--- a/en/tutorial-complete.html
+++ b/en/tutorial-complete.html
@@ -54,7 +54,11 @@
     <link rel="stylesheet" href="/css/page-with-sticky-toc.css">
 </head>
 <body>
-    <div id='app' data-local='en' data-page-name='tutorial-complete.html'>
+    <!-- loading overlay -->
+    <div id="loading-overlay" style="background-color: white; position:absolute; top:0px; left:0px; width:100%; height:100%; z-index:1000;"></div>
+
+    <!-- app -->
+    <div id='app' v-cloak data-local='en' data-page-name='tutorial-complete.html'>
         <!-- Navbar -->
         <app-nav-bar></app-nav-bar>
 

--- a/en/tutorial-recap.html
+++ b/en/tutorial-recap.html
@@ -55,7 +55,11 @@
     <link rel="stylesheet" href="/css/tutorial-recap.css">
 </head>
 <body>
-    <div id='app' data-local='en' data-page-name='tutorial-recap.html'>
+    <!-- loading overlay -->
+    <div id="loading-overlay" style="background-color: white; position:absolute; top:0px; left:0px; width:100%; height:100%; z-index:1000;"></div>
+
+    <!-- app -->
+    <div id='app' v-cloak data-local='en' data-page-name='tutorial-recap.html'>
     <!-- Navbar -->
     <app-nav-bar></app-nav-bar>
 

--- a/en/tutorial.html
+++ b/en/tutorial.html
@@ -54,7 +54,11 @@
     <link rel="stylesheet" href="/css/page-with-sticky-toc.css">
 </head>
 <body>
-    <div id='app' data-local='en' data-page-name='tutorial.html'>
+    <!-- loading overlay -->
+    <div id="loading-overlay" style="background-color: white; position:absolute; top:0px; left:0px; width:100%; height:100%; z-index:1000;"></div>
+
+    <!-- app -->
+    <div id='app' v-cloak data-local='en' data-page-name='tutorial.html'>
         <!-- Navbar -->
         <app-nav-bar></app-nav-bar>
 

--- a/en/typing.html
+++ b/en/typing.html
@@ -54,7 +54,11 @@
     <link rel="stylesheet" href="/css/typing.css">
 </head>
 <body>
-    <div id='app' data-local='en' data-page-name='typing.html'>
+    <!-- loading overlay -->
+    <div id="loading-overlay" style="background-color: white; position:absolute; top:0px; left:0px; width:100%; height:100%; z-index:1000;"></div>
+
+    <!-- app -->
+    <div id='app' v-cloak data-local='en' data-page-name='typing.html'>
     <!-- Navbar -->
     <app-nav-bar></app-nav-bar>
 

--- a/faq.html
+++ b/faq.html
@@ -53,7 +53,11 @@
     <link rel="stylesheet" href="/css/style.css">
 </head>
 <body>
-    <div id='app' data-local='tw' data-page-name='faq.html'>
+    <!-- loading overlay -->
+    <div id="loading-overlay" style="background-color: white; position:absolute; top:0px; left:0px; width:100%; height:100%; z-index:1000;"></div>
+
+    <!-- app -->
+    <div id='app' v-cloak data-local='tw' data-page-name='faq.html'>
         <!-- Navbar -->
         <app-nav-bar></app-nav-bar>
 

--- a/fr/about.html
+++ b/fr/about.html
@@ -54,7 +54,11 @@
     <link rel="stylesheet" href="/css/article.css">
 </head>
 <body>
-    <div id='app' data-local='fr' data-page-name='about.html'>
+    <!-- loading overlay -->
+    <div id="loading-overlay" style="background-color: white; position:absolute; top:0px; left:0px; width:100%; height:100%; z-index:1000;"></div>
+
+    <!-- app -->
+    <div id='app' v-cloak data-local='fr' data-page-name='about.html'>
         <!-- Navbar -->
         <app-nav-bar></app-nav-bar>
 

--- a/fr/dictionary.html
+++ b/fr/dictionary.html
@@ -54,7 +54,11 @@
     <link rel="stylesheet" href="/css/dictionary.css">
 </head>
 <body>
-    <div id='app' data-local='fr' data-page-name='dictionary.html'>
+    <!-- loading overlay -->
+    <div id="loading-overlay" style="background-color: white; position:absolute; top:0px; left:0px; width:100%; height:100%; z-index:1000;"></div>
+
+    <!-- app -->
+    <div id='app' v-cloak data-local='fr' data-page-name='dictionary.html'>
     <!-- Navbar -->
     <app-nav-bar></app-nav-bar>
 

--- a/fr/download.html
+++ b/fr/download.html
@@ -54,7 +54,11 @@
     <link rel="stylesheet" href="/css/page-with-sticky-toc.css">
 </head>
 <body>
-    <div id='app' data-local='fr' data-page-name='download.html'>
+    <!-- loading overlay -->
+    <div id="loading-overlay" style="background-color: white; position:absolute; top:0px; left:0px; width:100%; height:100%; z-index:1000;"></div>
+
+    <!-- app -->
+    <div id='app' v-cloak data-local='fr' data-page-name='download.html'>
         <!-- Navbar -->
         <app-nav-bar></app-nav-bar>
     

--- a/fr/faq.html
+++ b/fr/faq.html
@@ -53,7 +53,11 @@
     <link rel="stylesheet" href="/css/style.css">
 </head>
 <body>
-    <div id='app' data-local='fr' data-page-name='faq.html'>
+    <!-- loading overlay -->
+    <div id="loading-overlay" style="background-color: white; position:absolute; top:0px; left:0px; width:100%; height:100%; z-index:1000;"></div>
+
+    <!-- app -->
+    <div id='app' v-cloak data-local='fr' data-page-name='faq.html'>
         <!-- Navbar -->
         <app-nav-bar></app-nav-bar>
 

--- a/fr/index.html
+++ b/fr/index.html
@@ -55,7 +55,11 @@
     <link rel="stylesheet" href="/css/index.css">
 </head>
 <body>
-    <div id='app' data-local='fr' data-page-name='index.html'>
+    <!-- loading overlay -->
+    <div id="loading-overlay" style="background-color: white; position:absolute; top:0px; left:0px; width:100%; height:100%; z-index:1000;"></div>
+
+    <!-- app -->
+    <div id='app' v-cloak data-local='fr' data-page-name='index.html'>
     <!-- Navbar -->
     <app-nav-bar></app-nav-bar>
 

--- a/fr/radicals-and-examples.html
+++ b/fr/radicals-and-examples.html
@@ -54,7 +54,11 @@
     <link rel="stylesheet" href="/css/radicals-and-examples.css">
 </head>
 <body>
-    <div id='app' data-local='fr' data-page-name='radicals-and-examples.html'>
+    <!-- loading overlay -->
+    <div id="loading-overlay" style="background-color: white; position:absolute; top:0px; left:0px; width:100%; height:100%; z-index:1000;"></div>
+
+    <!-- app -->
+    <div id='app' v-cloak data-local='fr' data-page-name='radicals-and-examples.html'>
         <!-- Navbar -->
         <app-nav-bar></app-nav-bar>
 

--- a/fr/tutorial-complete.html
+++ b/fr/tutorial-complete.html
@@ -54,7 +54,11 @@
     <link rel="stylesheet" href="/css/page-with-sticky-toc.css">
 </head>
 <body>
-    <div id='app' data-local='fr' data-page-name='tutorial-complete.html'>
+    <!-- loading overlay -->
+    <div id="loading-overlay" style="background-color: white; position:absolute; top:0px; left:0px; width:100%; height:100%; z-index:1000;"></div>
+
+    <!-- app -->
+    <div id='app' v-cloak data-local='fr' data-page-name='tutorial-complete.html'>
         <!-- Navbar -->
         <app-nav-bar></app-nav-bar>
 

--- a/fr/tutorial-recap.html
+++ b/fr/tutorial-recap.html
@@ -55,7 +55,11 @@
     <link rel="stylesheet" href="/css/tutorial-recap.css">
 </head>
 <body>
-    <div id='app' data-local='fr' data-page-name='tutorial-recap.html'>
+    <!-- loading overlay -->
+    <div id="loading-overlay" style="background-color: white; position:absolute; top:0px; left:0px; width:100%; height:100%; z-index:1000;"></div>
+
+    <!-- app -->
+    <div id='app' v-cloak data-local='fr' data-page-name='tutorial-recap.html'>
     <!-- Navbar -->
     <app-nav-bar></app-nav-bar>
 

--- a/fr/tutorial.html
+++ b/fr/tutorial.html
@@ -54,7 +54,11 @@
     <link rel="stylesheet" href="/css/page-with-sticky-toc.css">
 </head>
 <body>
-    <div id='app' data-local='fr' data-page-name='tutorial.html'>
+    <!-- loading overlay -->
+    <div id="loading-overlay" style="background-color: white; position:absolute; top:0px; left:0px; width:100%; height:100%; z-index:1000;"></div>
+
+    <!-- app -->
+    <div id='app' v-cloak data-local='fr' data-page-name='tutorial.html'>
         <!-- Navbar -->
         <app-nav-bar></app-nav-bar>
 

--- a/fr/typing.html
+++ b/fr/typing.html
@@ -54,7 +54,11 @@
     <link rel="stylesheet" href="/css/typing.css">
 </head>
 <body>
-    <div id='app' data-local='fr' data-page-name='typing.html'>
+    <!-- loading overlay -->
+    <div id="loading-overlay" style="background-color: white; position:absolute; top:0px; left:0px; width:100%; height:100%; z-index:1000;"></div>
+
+    <!-- app -->
+    <div id='app' v-cloak data-local='fr' data-page-name='typing.html'>
     <!-- Navbar -->
     <app-nav-bar></app-nav-bar>
 

--- a/index.html
+++ b/index.html
@@ -55,7 +55,11 @@
     <link rel="stylesheet" href="/css/index.css">
 </head>
 <body>
-    <div id='app' data-local='tw' data-page-name='index.html'>
+    <!-- loading overlay -->
+    <div id="loading-overlay" style="background-color: white; position:absolute; top:0px; left:0px; width:100%; height:100%; z-index:1000;"></div>
+
+    <!-- app -->
+    <div id='app' v-cloak data-local='tw' data-page-name='index.html'>
     <!-- Navbar -->
     <app-nav-bar></app-nav-bar>
 

--- a/radicals-and-examples.html
+++ b/radicals-and-examples.html
@@ -54,7 +54,11 @@
     <link rel="stylesheet" href="/css/radicals-and-examples.css">
 </head>
 <body>
-    <div id='app' data-local='tw' data-page-name='radicals-and-examples.html'>
+    <!-- loading overlay -->
+    <div id="loading-overlay" style="background-color: white; position:absolute; top:0px; left:0px; width:100%; height:100%; z-index:1000;"></div>
+
+    <!-- app -->
+    <div id='app' v-cloak data-local='tw' data-page-name='radicals-and-examples.html'>
         <!-- Navbar -->
         <app-nav-bar></app-nav-bar>
 

--- a/tutorial-complete.html
+++ b/tutorial-complete.html
@@ -54,7 +54,11 @@
     <link rel="stylesheet" href="/css/page-with-sticky-toc.css">
 </head>
 <body>
-    <div id='app' data-local='tw' data-page-name='tutorial-complete.html'>
+    <!-- loading overlay -->
+    <div id="loading-overlay" style="background-color: white; position:absolute; top:0px; left:0px; width:100%; height:100%; z-index:1000;"></div>
+
+    <!-- app -->
+    <div id='app' v-cloak data-local='tw' data-page-name='tutorial-complete.html'>
         <!-- Navbar -->
         <app-nav-bar></app-nav-bar>
 

--- a/tutorial-recap.html
+++ b/tutorial-recap.html
@@ -55,7 +55,11 @@
     <link rel="stylesheet" href="/css/tutorial-recap.css">
 </head>
 <body>
-    <div id='app' data-local='tw' data-page-name='tutorial-recap.html'>
+    <!-- loading overlay -->
+    <div id="loading-overlay" style="background-color: white; position:absolute; top:0px; left:0px; width:100%; height:100%; z-index:1000;"></div>
+
+    <!-- app -->
+    <div id='app' v-cloak data-local='tw' data-page-name='tutorial-recap.html'>
     <!-- Navbar -->
     <app-nav-bar></app-nav-bar>
 

--- a/tutorial.html
+++ b/tutorial.html
@@ -54,7 +54,11 @@
     <link rel="stylesheet" href="/css/page-with-sticky-toc.css">
 </head>
 <body>
-    <div id='app' data-local='tw' data-page-name='tutorial.html'>
+    <!-- loading overlay -->
+    <div id="loading-overlay" style="background-color: white; position:absolute; top:0px; left:0px; width:100%; height:100%; z-index:1000;"></div>
+
+    <!-- app -->
+    <div id='app' v-cloak data-local='tw' data-page-name='tutorial.html'>
         <!-- Navbar -->
         <app-nav-bar></app-nav-bar>
 

--- a/typing.html
+++ b/typing.html
@@ -54,7 +54,11 @@
     <link rel="stylesheet" href="/css/typing.css">
 </head>
 <body>
-    <div id='app' data-local='tw' data-page-name='typing.html'>
+    <!-- loading overlay -->
+    <div id="loading-overlay" style="background-color: white; position:absolute; top:0px; left:0px; width:100%; height:100%; z-index:1000;"></div>
+
+    <!-- app -->
+    <div id='app' v-cloak data-local='tw' data-page-name='typing.html'>
     <!-- Navbar -->
     <app-nav-bar></app-nav-bar>
 


### PR DESCRIPTION
Fix the loading screen problem (Vue app brackets displayed while rendering) by
- adding v-cloak and corresponding css style
    - which doens't work perfectly, due to css file loading delay (I guess...)
- and therefore by also adding a loading overlay which is removed after v-clock css has been loaded

Normally there's no more Vue app brackets shown on the screen during page loading, instead, 'Loading...' or pure white screen will be displayed. But sometimes (rarely) a few Vue brackets can still be seen (to be further investigated...)