### PR TITLE
Change input font dictionary typing

### DIFF
--- a/css/dictionary.css
+++ b/css/dictionary.css
@@ -35,6 +35,7 @@
   margin: 8px;
   border-radius: 20px;
   border: 1.5px solid #cccccc;
+  font-family: "Noto Serif", "Noto Serif TC", "Noto Serif CJK TC", "Noto Serif CJK SC", serif;
 }
 #inputCharacters:focus {
   border: 1.5px solid #333333;

--- a/css/typing.css
+++ b/css/typing.css
@@ -115,6 +115,7 @@
   font-size: 1.2em;
   clear: both;
   border: 1.5px solid transparent;
+  font-family: "Noto Serif", "Noto Serif TC", "Noto Serif CJK TC", "Noto Serif CJK SC", serif;
 }
 .typing-input-field:focus {
   border: 1.5px solid #11471a;
@@ -175,6 +176,19 @@
 }
 .btn-built-in-exer:hover {
   background-color: #cfcfcf;
+}
+
+/* create your own exercise */
+#input_cust_exer {
+  padding: 8px;
+  width: 95%;
+  border: 1.5px solid #cccccc;
+  border-radius: 15px;
+  font-family: "Noto Serif", "Noto Serif TC", "Noto Serif CJK TC", "Noto Serif CJK SC", serif;
+}
+#input_cust_exer:focus {
+  border: 1.5px solid #303030;
+  outline: none;
 }
 
 /*------- buy me a cake -------*/

--- a/en/typing.html
+++ b/en/typing.html
@@ -506,7 +506,7 @@
                     </div>
                     <div class="typing-block-dtls-first">
                         <div id='cust_exer_hint' class="typing-block-cust-exer-hint"></div>
-                        <textarea id='input_cust_exer' rows="4" class="w3-border w3-border-dark-gray w3-round-large" style="padding: 8px; width: 95%;" :placeholder="appContent.exercises.customisation.inputPlaceholder[local]"></textarea>
+                        <textarea id='input_cust_exer' rows="4" :placeholder="appContent.exercises.customisation.inputPlaceholder[local]"></textarea>
                         <button id="btn_submit_cust_exer" class="btn-built-in-exer w3-margin-bottom">{{ appContent.exercises.customisation.creation[local] }}*</button>
                         <br>
                         <div class="w3-round-large w3-margin-bottom" style="font-size: small">

--- a/fr/typing.html
+++ b/fr/typing.html
@@ -506,7 +506,7 @@
                     </div>
                     <div class="typing-block-dtls-first">
                         <div id='cust_exer_hint' class="typing-block-cust-exer-hint"></div>
-                        <textarea id='input_cust_exer' rows="4" class="w3-border w3-border-dark-gray w3-round-large" style="padding: 8px; width: 95%;" :placeholder="appContent.exercises.customisation.inputPlaceholder[local]"></textarea>
+                        <textarea id='input_cust_exer' rows="4" :placeholder="appContent.exercises.customisation.inputPlaceholder[local]"></textarea>
                         <button id="btn_submit_cust_exer" class="btn-built-in-exer w3-margin-bottom">{{ appContent.exercises.customisation.creation[local] }}*</button>
                         <br>
                         <div class="w3-round-large w3-margin-bottom" style="font-size: small">

--- a/typing.html
+++ b/typing.html
@@ -506,7 +506,7 @@
                     </div>
                     <div class="typing-block-dtls-first">
                         <div id='cust_exer_hint' class="typing-block-cust-exer-hint"></div>
-                        <textarea id='input_cust_exer' rows="4" class="w3-border w3-border-dark-gray w3-round-large" style="padding: 8px; width: 95%;" :placeholder="appContent.exercises.customisation.inputPlaceholder[local]"></textarea>
+                        <textarea id='input_cust_exer' rows="4" :placeholder="appContent.exercises.customisation.inputPlaceholder[local]"></textarea>
                         <button id="btn_submit_cust_exer" class="btn-built-in-exer w3-margin-bottom">{{ appContent.exercises.customisation.creation[local] }}*</button>
                         <br>
                         <div class="w3-round-large w3-margin-bottom" style="font-size: small">


### PR DESCRIPTION
Set the family font of the input fields in typing/dictionary to be Noto Serif, since the font 'Domine' doesn't support ^ very well.